### PR TITLE
Added check to see if the target PNG is the same file as the source PNG for non-CgBI PNG files.

### DIFF
--- a/src/main/java/com/kylinworks/IPngConverter.java
+++ b/src/main/java/com/kylinworks/IPngConverter.java
@@ -98,7 +98,7 @@ public class IPngConverter {
 
       writePng(targetFile);
 
-    } else {
+    } else if(!pngFile.equals(targetFile)) {
       // Likely a standard PNG: just copy
       byte[] buffer = new byte[1024];
       int bytesRead;


### PR DESCRIPTION
Added check to see if the target PNG is the same file as the source PNG for non-CgBI PNG files.

The reason for this is because if you use the same file for both target and source when creating a converter, like shown in the example below...

`IPngConverter converter = new IPngConverter(file, file);`

...then if the file is non-CgBI, the code will attempt to read from and write to the file at the same time, which ends up completely erasing it. This solution determines if the source file is the same as the target file, in which case nothing is done to the file.
